### PR TITLE
add options in swap fstab file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,8 +32,8 @@ class swap_file (
   $ensure        = 'present',
   $swapfile      = '/mnt/swap.1',
   $swapfilesize  = $::memorysize,
-  $add_mount     = true
-  $options       = 'defaults',
+  $add_mount     = true,
+  $options       = 'defaults'
 ) inherits swap_file::params {
 
   # Parameter validation


### PR DESCRIPTION
https://docs.puppetlabs.com/references/latest/type.html#mount
fix for issue https://github.com/petems/puppet-swap_file/issues/5

```
options
(Property: This attribute represents concrete state on the target system.)

Mount options for the mounts, as they would appear in the fstab.
```
