### PR TITLE
Minor fixes and $swapfiles hash parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,24 @@ swap_file::files { 'tmp file swap':
 }
 ```
 
+You can create several swap_file::files resources by passing them as a hash to
+the main class. In Hiera you would do this:
+
+```
+# Create two additional swapfiles using the $swapfiles parameter
+swap_file::swapfiles:
+  swap0:
+    ensure: 'present'
+    swapfile: '/swapfile.0'
+    swapfilesize: '1024MB'
+  swap1:
+    ensure: 'present'
+    swapfile: '/swapfile.1'
+```
+
+This same approach can be used in Foreman, which does not support creating
+defined resources directly.
+
 ## Previous to 1.0.1 Release
 
 Previously you would create swapfiles with the `swap_file` class:

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -69,7 +69,7 @@ define swap_file::files (
     }
   }
   elsif $ensure == 'absent' {
-    exec { 'Detach swap file ${swapfile}':
+    exec { "Detach swap file ${swapfile}":
       command => "/sbin/swapoff ${swapfile}",
       onlyif  => "/sbin/swapon -s | grep ${swapfile}",
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,12 +12,16 @@
 # [*swapfilesize*]
 #   Size of the swapfile as a string (eg. 10 MB, 1.2 GB).
 #   Defaults to $::memorysize fact on the node
+# [*swapfiles*]
+#   A hash of ::swap_file::files resources to realize.
 # [*add_mount*]
 #   Add a mount to the swapfile so it persists on boot
 # [*options*]
 #   Mount options for the swapfile
 #
 # == Examples
+#
+# Usage in Puppet code:
 #
 #   include swap_file
 #
@@ -30,6 +34,21 @@
 #     swapfilesize => '100 MB',
 #   }
 #
+# Usage in Hiera or Foreman:
+#
+#   # Don't create the default swapfile
+#   swap_file::ensure: 'absent'
+#
+#   # Create two swapfiles using the $swapfiles parameter
+#   swap_file::swapfiles:
+#     swap0:
+#       ensure: 'present'
+#       swapfile: '/swapfile.0'
+#       swapfilesize: '1024MB'
+#     swap1:
+#       ensure: 'present'
+#       swapfile: '/swapfile.1'
+#
 # == Authors
 #    @petems - Peter Souter
 #    @Yggdrasil
@@ -38,6 +57,7 @@ class swap_file (
   $ensure        = 'present',
   $swapfile      = '/mnt/swap.1',
   $swapfilesize  = $::memorysize,
+  $swapfiles     = {},
   $add_mount     = true,
   $options       = 'defaults'
 ) inherits swap_file::params {
@@ -46,6 +66,7 @@ class swap_file (
   validate_re($ensure, ['^absent$', '^present$'], "Invalid ensure: ${ensure} - (Must be 'present' or 'absent')")
   validate_string($swapfile)
   $swapfilesize_mb = to_bytes($swapfilesize) / 1000000
+  validate_hash($swapfiles)
   validate_bool($add_mount)
 
   warning('Use of swap_file class is now deprecated')
@@ -65,4 +86,7 @@ class swap_file (
       ensure        => 'absent',
     }
   }
+
+  # Create defined resources from the $swapfiles parameter
+  create_resources('swap_file::files', $swapfiles)
 }

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -9,4 +9,4 @@
 # Learn more about module testing here:
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
-include swap_file
+include ::swap_file


### PR DESCRIPTION
Hi,

I added a new hash parameter $swapfiles to the main class. It allows creating zero or more swapfiles without having to directly use defined resources. This is in practice necessary on Foreman, which does not support directly adding (defined) resources to nodes. This is also very useful on Hiera, even though not strictly speaking necessary. Use of these hash parameters combined with create_resources is a standard approach I've used in my own modules with great success.

The new $swapfiles parameter would also allow you to scrap the "default" swapfile creation in the main class, making it a very simple wrapper for the create_resources call. That change would of course  break existing configurations and would warrant big warnings and probably a new major version number.