### PR TITLE
Fix: exec contains swapfile name when absent

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -69,7 +69,7 @@ define swap_file::files (
     }
   }
   elsif $ensure == 'absent' {
-    exec { 'Detach swap file ${swapfile}':
+    exec { "Detach swap file ${swapfile}":
       command => "/sbin/swapoff ${swapfile}",
       onlyif  => "/sbin/swapon -s | grep ${swapfile}",
     }
@@ -83,6 +83,5 @@ define swap_file::files (
       device => $swapfile,
     }
   }
-
 
 }


### PR DESCRIPTION
Hi!

Fix for error when ensure is set to absent: Could not find dependency Exec[Detach swap file /swapfile] for File[/swapfile]...
No tests...

Thanks!
