### PR TITLE
Adds `cmd` parameter.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ Manage [swap files](http://en.wikipedia.org/wiki/Paging) for your Linux environm
 
 ###What swap_file affects
 
-* Creating files from the path given using `/bin/dd` by default or `/usr/bin/fallocate` optionally for performance reasons.
+* Creating a swap-file on disk. This uses `dd` by default, but can use `fallocate` optionally for performance reasons. **Note: Using fallocate to create a ZFS file system will fail: https://bugzilla.redhat.com/show_bug.cgi?id=1129205**
 * Swapfiles on the system
 * Any mounts of swapfiles
 
@@ -44,7 +44,8 @@ swap_file::files { 'tmp file swap':
   add_mount => false,
 }
 ```
-To use fallocate for swap file creation instead of dd do this:
+
+To use `fallocate` for swap file creation instead of `dd`:
 
 ```puppet
 swap_file::files { 'tmp file swap':
@@ -52,7 +53,7 @@ swap_file::files { 'tmp file swap':
   swapfile  => '/tmp/swapfile',
   cmd       => 'fallocate',
 }
-```
+
 
 To remove a prexisting swap, you can use ensure absent:
 

--- a/spec/defines/files_spec.rb
+++ b/spec/defines/files_spec.rb
@@ -86,4 +86,39 @@ describe 'swap_file::files' do
     end
   end
 
+  context 'custom swapfilesize parameter with timeout' do
+    let(:params) do
+      {
+        :swapfile => "/mnt/swap.2",
+        :swapfilesize => '4.1 GB',
+        :timeout => 900,
+      }
+    end
+    it do
+      is_expected.to compile.with_all_deps
+    end
+    it do
+      is_expected.to contain_exec('Create swap file /mnt/swap.2').
+      with({"command"=>"/bin/dd if=/dev/zero of=/mnt/swap.2 bs=1M count=4402",
+       "timeout"=>900,"creates"=>"/mnt/swap.2"})
+    end
+  end
+
+  context 'custom swapfilesize parameter with fallocate' do
+    let(:params) do
+      {
+        :swapfile => "/mnt/swap.3",
+        :swapfilesize => '4.1 GB',
+        :cmd => 'fallocate',
+      }
+      it do
+        is_expected.to compile.with_all_deps
+      end
+      is_expected.to contain_exec('Create swap file /mnt/swap.3').
+        with(
+          {"command"=>"/usr/bin/fallocate -l 4402M /mnt/swap.3",
+            "creates"=>"/mnt/swap.3"}
+        )
+    end
+  end
 end


### PR DESCRIPTION
* Defaults to `dd` but allows for the use of `fallocate` for performance.
* Added cmd option to spec file.
* Added note to README for XFS issues

Squashed version of https://github.com/petems/puppet-swap_file/pull/33