### PR TITLE
Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 .*.sw?
 pkg
-spec/fixtures
 .rspec_system
 .vagrant/
 log/
 junit/
 .yar*
 doc/
+
+# Puppet
 coverage/
+spec/fixtures/modules/*
+spec/fixtures/manifests/*
 Gemfile.lock

--- a/examples/hiera/common.yaml
+++ b/examples/hiera/common.yaml
@@ -1,0 +1,12 @@
+---
+classes:
+  - swap_file
+
+swap_file::files:
+  'from_common':
+    ensure:   'present'
+    swapfile: '/mnt/swap.common'
+
+# This will:
+# - call the class swap_file
+# - create a file '/mnt/swap.common' using /bin/dd with the default size taken from the $::memorysizeinbytes and create a mount for it.

--- a/examples/hiera/fqdn/merge_disabled.domain.local.yaml
+++ b/examples/hiera/fqdn/merge_disabled.domain.local.yaml
@@ -1,0 +1,13 @@
+---
+swap_file::files_hiera_merge: false
+swap_file::files:
+  'from_fqdn':
+    ensure:       'present'
+    swapfile:     '/mnt/swap.fqdn'
+    swapfilesize: '2 GB'
+    cmd:          'fallocate'
+
+# Because files_hiera_merge is set to false, this will create only the swapfiles specified in the most specific hiera level.
+
+# This will:
+# - create a file '/mnt/swap.fqdn' using /usr/bin/fallocate with size set to '2 GB' and creates mount for it.

--- a/examples/hiera/fqdn/merge_enabled.domain.local.yaml
+++ b/examples/hiera/fqdn/merge_enabled.domain.local.yaml
@@ -1,0 +1,16 @@
+---
+swap_file::files_hiera_merge: true
+swap_file::files:
+  'from_fqdn':
+    ensure:       'present'
+    swapfile:     '/mnt/swap.fqdn'
+    swapfilesize: '2 GB'
+    cmd:          'fallocate'
+
+# Because files_hiera_merge is set to true, this will create all swapfiles specified in different hiera levels.
+
+# This will:
+# - create a file '/mnt/swap.common' using /bin/dd with the default size taken from the $::memorysizeinbytes and create a mount for it.
+# - create a file '/mnt/swap.fqdn' using /usr/bin/fallocate with size set to '2 GB' and creates mount for it.
+
+

--- a/examples/hiera/hiera.yaml
+++ b/examples/hiera/hiera.yaml
@@ -1,0 +1,6 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - fqdn/%{fqdn}
+  - common

--- a/examples/multiple_swaps.pp
+++ b/examples/multiple_swaps.pp
@@ -1,0 +1,17 @@
+node default {
+  class { 'swap_file':
+    files => {
+      'swapfile' => {
+        ensure => 'present',
+      },
+      'use fallocate' => {
+        swapfile => '/tmp/swapfile.fallocate',
+        cmd      => 'fallocate',
+      },
+      'remove swap file' => {
+        ensure   => 'absent',
+        swapfile => '/tmp/swapfile.old',
+      },
+    },
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,71 @@
+# == Class: swap_file
+#
+# == Parameters
+# [*files*]
+#   Hash of swap files to ensure with swap_file::files
+# [*files_hiera_merge*]
+#   Boolean to merge all found instances of swap_file::files in Hiera.
+#   This can be used to specify swap files at different levels an have
+#   them all included in the catalog.
+#   Defaults to false
+#
+# == Examples
+#
+#   class { 'swap_file':
+#     'files' => {
+#       'resource_name' => {
+#         ensure   => present,
+#         swapfile => '/mnt/swap',
+#       },
+#     },
+#   }
+#   Will create one swapfile in /mnt/swap using the defaults.
+#
+#   class { 'swap_file':
+#     'files' => {
+#       'swap1' => {
+#         ensure       => present,
+#         swapfile     => '/mnt/swap.1',
+#         swapfilesize => '1 GB',
+#       },
+#       'swap2' => {
+#         ensure       => present,
+#         swapfile     => '/mnt/swap.2',
+#         swapfilesize => '2 GB',
+#         cmd          => 'fallocate',
+#       },
+#     },
+#   }
+#   Will create two swapfile with the given parameters
+#
+#   class { 'swap_file':
+#     files_hiera_merge: true,
+#   }
+#   Will merge all found instances of swap_file::files found in hiera and
+#   create resources for these.
+#
+
+class swap_file (
+  $files             = {},
+  $files_hiera_merge = false,
+) {
+
+  # variable handling
+  if is_bool($files_hiera_merge) == true {
+    $files_hiera_merge_bool = $files_hiera_merge
+  } else {
+    $files_hiera_merge_bool = str2bool($files_hiera_merge)
+  }
+  validate_bool($files_hiera_merge_bool)
+
+  # functionality
+  if $files_hiera_merge_bool == true {
+    $files_real = hiera_hash('swap_file::files', {})
+  } else {
+    $files_real = $files
+  }
+  if $files_real != undef {
+    validate_hash($files_real)
+    create_resources('swap_file::files', $files_real)
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+describe 'swap_file' do
+  context 'with defaults for all parameters' do
+    it { should compile.with_all_deps }
+    it { should contain_class('swap_file') }
+    it { should have_resource_count(0) }
+  end
+
+  context 'with files set to valid hash' do
+    let(:params) do
+      {
+        :files => {
+          'swap' => {
+            'ensure' => 'present',
+          },
+          'test' => {
+            'swapfile' => '/mnt/test',
+          },
+        }
+      }
+    end
+
+    it { should compile.with_all_deps }
+    it { should contain_class('swap_file') }
+    # subclass swap_file::files adds 4 resources for each given file
+    it { should have_resource_count(10) }
+
+    it do
+      should contain_swap_file__files('swap').with({
+        'ensure' => 'present',
+      })
+    end
+
+    it do
+      should contain_swap_file__files('test').with({
+        'swapfile' => '/mnt/test',
+      })
+    end
+  end
+
+  describe 'with data for swap_file::files provided in multiple hiera levels' do
+    let(:facts) do
+      {
+        :fqdn              => 'files',
+        :parameter_tests   => 'files_hiera_merge',
+      }
+    end
+
+    context 'when files_hiera_merge is set to the default value <false>' do
+      let(:params) { { :files_hiera_merge => false } }
+      it { should compile.with_all_deps }
+      it { should contain_class('swap_file') }
+      it { should have_resource_count(5) }
+
+      it do
+        should contain_swap_file__files('resource_name').with({
+          'ensure'   => 'present',
+          'swapfile' => '/mnt/swap',
+        })
+      end
+    end
+
+    context 'when files_hiera_merge is set to valid value <true>' do
+      let(:params) { { :files_hiera_merge => true } }
+      it { should compile.with_all_deps }
+      it { should contain_class('swap_file') }
+      it { should have_resource_count(15) }
+
+      it do
+        should contain_swap_file__files('resource_name').with({
+          'ensure'   => 'present',
+          'swapfile' => '/mnt/swap',
+        })
+      end
+
+      it do
+        should contain_swap_file__files('swap1').with({
+          'ensure'       => 'present',
+          'swapfile'     => '/mnt/swap.1',
+          'swapfilesize' => '1 GB',
+        })
+      end
+
+      it do
+        should contain_swap_file__files('swap2').with({
+          'ensure'       => 'present',
+          'swapfile'     => '/mnt/swap.2',
+          'swapfilesize' => '2 GB',
+          'cmd'          => 'fallocate',
+        })
+      end
+    end
+  end
+
+  describe 'variable type and content validations' do
+    # set needed custom facts and variables
+    let(:facts) do
+      {
+        :osfamily => 'RedHat',
+      }
+    end
+    let(:validation_params) do
+      {
+        #:param => 'value',
+      }
+    end
+
+    validations = {
+      'bool_stringified' => {
+        :name    => %w(files_hiera_merge),
+        :valid   => [true, false, 'true', 'false'],
+        :invalid => ['invalid', %w(array), { 'ha' => 'sh' }, 3, 2.42, nil],
+        :message => '(Unknown type of boolean|str2bool\(\): Requires either string to work with)',
+      },
+      'hash' => {
+        :name    => %w(files),
+        :valid   => [{ 'swap' => { 'ensure' => 'present' } }],
+        :invalid => ['invalid', %w(array), 3, 2.42, true, false, nil],
+        :message => 'is not a Hash',
+      },
+    }
+
+    validations.sort.each do |type, var|
+      var[:name].each do |var_name|
+        var[:valid].each do |valid|
+          context "with #{var_name} (#{type}) set to valid #{valid} (as #{valid.class})" do
+            let(:params) { validation_params.merge({ :"#{var_name}" => valid, }) }
+            it { should compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "with #{var_name} (#{type}) set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { validation_params.merge({ :"#{var_name}" => invalid, }) }
+            it 'should fail' do
+              expect do
+                should contain_class(subject)
+              end.to raise_error(Puppet::Error, /#{var[:message]}/)
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
+end

--- a/spec/fixtures/hiera/fqdn/files.yaml
+++ b/spec/fixtures/hiera/fqdn/files.yaml
@@ -1,0 +1,5 @@
+---
+swap_file::files:
+  'resource_name':
+    ensure:   'present'
+    swapfile: '/mnt/swap'

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: 'spec/fixtures/hiera'
+:hierarchy:
+  - fqdn/%{fqdn}
+  - parameter_tests/%{parameter_tests}

--- a/spec/fixtures/hiera/parameter_tests/files_hiera_merge.yaml
+++ b/spec/fixtures/hiera/parameter_tests/files_hiera_merge.yaml
@@ -1,0 +1,11 @@
+---
+swap_file::files:
+  'swap1':
+    ensure:       'present'
+    swapfile:     '/mnt/swap.1'
+    swapfilesize: '1 GB'
+  'swap2':
+    ensure:       'present'
+    swapfile:     '/mnt/swap.2'
+    swapfilesize: '2 GB'
+    cmd:          'fallocate'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end


### PR DESCRIPTION
Since v2.0 it is not possible to use data from hiera. This adds init.pp as wrapper class to allow usage of hiera features like merging through levels.
