### PR TITLE
Bring module up to date

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@ fixtures:
   repositories:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: 4.23.0
     augeasproviders_sysctl:
       repo: "git://github.com/hercules-team/augeasproviders_sysctl.git"
     augeasproviders_core:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,12 @@
 fixtures:
   repositories:
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     augeasproviders_sysctl:
-      repo: "git://github.com/hercules-team/augeasproviders_sysctl.git"
+      repo: "https://github.com/voxpupuli/puppet-augeasproviders_sysctl.git"
     augeasproviders_core:
-      repo: "git://github.com/hercules-team/augeasproviders_core.git"
+      repo: "https://github.com/voxpupuli/puppet-augeasproviders_core.git"
     mount_core:
-      repo: "git://github.com/puppetlabs/puppetlabs-mount_core.git"
+      repo: "https://github.com/puppetlabs/puppetlabs-mount_core.git"
   symlinks:
     swap_file: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 .*.sw?
 pkg
+.bundle
 .rspec_system
 .vagrant/
 log/
 junit/
 .yar*
 doc/
+vendor/
 
 # Puppet
 coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -4,20 +4,14 @@ group :test do
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion, :require => false
   else
-    gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.0'
+    gem 'puppet', ENV['PUPPET_VERSION'] || '~> 7.12.0'
   end
 
-  # rspec must be v2 for ruby 1.8.7
-  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-    gem 'rspec', '~> 2.0'
-  end
-
-  gem 'json_pure', '<= 2.0.1',  :require => false if RUBY_VERSION < '2.0.0'
-  gem 'safe_yaml', '~> 1.0.4'
-
+  gem 'rspec'
+  gem 'safe_yaml'
   gem 'rake'
   gem 'puppet-lint'
-  gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'rspec-puppet'
   gem 'puppet-syntax'
   gem 'puppetlabs_spec_helper'
   gem 'simplecov'
@@ -27,21 +21,15 @@ end
 
 group :development do
   gem 'puppet-blacksmith'
-  gem 'rubocop' if RUBY_VERSION >= '2.0.0'
-  gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop'
+  gem 'rubocop-rspec'
   gem 'github_changelog_generator'
-  gem 'activesupport', '< 5'
+  gem 'activesupport'
 end
 
 group :system_tests do
-  gem "beaker",
-    :git => 'https://github.com/puppetlabs/beaker',
-    :ref => '3d21e843434a2e65152bd352c653511ddea0ce71',
-    :require => false
-  gem "beaker-rspec",
-    :git => 'https://github.com/puppetlabs/beaker-rspec.git',
-    :ref => 'a617f7bbc3e6ebb6ce49df32749d4ce93cef737d',
-    :require => false
+  gem "beaker"
+  gem "beaker-rspec"
   gem 'serverspec'
   gem 'specinfra'
 end

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -34,7 +34,7 @@
 define swap_file::files (
   $ensure        = 'present',
   $swapfile      = '/mnt/swap.1',
-  $swapfilesize  = $::memorysize,
+  $swapfilesize  = $facts['memory']['system']['total'],
   $add_mount     = true,
   $options       = 'defaults',
   $timeout       = 300,
@@ -52,23 +52,23 @@ define swap_file::files (
 
   if $ensure == 'present' {
 
-    if ($resize_existing and $::swapfile_sizes) {
+    if ($resize_existing and $facts['swapfile_sizes']) {
 
-      if (is_hash($::swapfile_sizes)) {
+      if (is_hash($facts['swapfile_sizes'])) {
 
-        if (has_key($::swapfile_sizes,$swapfile)) {
+        if (has_key($facts['swapfile_sizes'],$swapfile)) {
           ::swap_file::resize { $swapfile:
             swapfile_path          => $swapfile,
             margin                 => $resize_margin,
             expected_swapfile_size => $swapfilesize,
-            actual_swapfile_size   => $::swapfile_sizes[$swapfile],
+            actual_swapfile_size   => $facts['swapfile_sizes'][$swapfile],
             verbose                => $resize_verbose,
             before                 => Exec["Create swap file ${swapfile}"],
           }
         }
 
       } else {
-        $existing_swapfile_size = swap_file_size_from_csv($swapfile,$::swapfile_sizes_csv)
+        $existing_swapfile_size = swap_file_size_from_csv($swapfile,$facts['swapfile_sizes_csv'])
         if ($existing_swapfile_size) {
           ::swap_file::resize { $swapfile:
             swapfile_path          => $swapfile,
@@ -104,7 +104,7 @@ define swap_file::files (
       require => Exec["Create swap file ${swapfile}"],
     }
 
-    if $::selinux {
+    if $facts['os']['selinux']['enabled'] {
       File[$swapfile] {
         seltype => 'swapfile_t',
       }

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -53,7 +53,7 @@ define swap_file::files (
 
       if ($facts['swapfile_sizes'] =~ Hash) {
 
-        if (has_key($facts['swapfile_sizes'],$swapfile)) {
+        if ($swapfile in $facts['swapfile_sizes']) {
           ::swap_file::resize { $swapfile:
             swapfile_path          => $swapfile,
             margin                 => $resize_margin,

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -51,7 +51,7 @@ define swap_file::files (
 
     if ($resize_existing and $facts['swapfile_sizes']) {
 
-      if (is_hash($facts['swapfile_sizes'])) {
+      if ($facts['swapfile_sizes'] =~ Hash) {
 
         if (has_key($facts['swapfile_sizes'],$swapfile)) {
           ::swap_file::resize { $swapfile:

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -32,10 +32,10 @@
 #    @petems - Peter Souter
 #
 define swap_file::files (
-  $ensure        = 'present',
-  $swapfile      = '/mnt/swap.1',
+  Enum['absent', 'present'] $ensure = 'present',
+  String[1] $swapfile = '/mnt/swap.1',
   $swapfilesize  = $facts['memory']['system']['total'],
-  $add_mount     = true,
+  Boolean $add_mount = true,
   $options       = 'defaults',
   $timeout       = 300,
   $cmd           = 'dd',
@@ -45,10 +45,7 @@ define swap_file::files (
 )
 {
   # Parameter validation
-  validate_legacy(String, 'validate_re', $ensure, ['^absent$', '^present$'])
-  validate_legacy(String, 'validate_string', $swapfile)
   $swapfilesize_mb = to_bytes($swapfilesize) / 1048576
-  validate_legacy(Boolean, 'validate_bool', $add_mount)
 
   if $ensure == 'present' {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,6 @@ class swap_file (
   } else {
     $files_hiera_merge_bool = str2bool($files_hiera_merge)
   }
-  validate_legacy(Boolean, 'validate_bool', $files_hiera_merge_bool)
 
   # functionality
   if $files_hiera_merge_bool == true {
@@ -58,8 +57,7 @@ class swap_file (
   } else {
     $files_real = $files
   }
-  if $files_real != undef {
-    validate_legacy(Hash, 'validate_hash', $files_real)
+  if $files_real =~ Hash {
     create_resources('swap_file::files', $files_real)
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 # @author - Peter Souter
 #
 class swap_file (
-  $files             = {},
+  Hash $files             = {},
   $files_hiera_merge = false,
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,10 @@ class swap_file (
     $files_real = $files
   }
   if $files_real =~ Hash {
-    create_resources('swap_file::files', $files_real)
+    $files_real.each | $_key, $_values | {
+      swap_file::files{$_key:
+        * => $_values,
+      }
+    }
   }
 }

--- a/manifests/swappiness.pp
+++ b/manifests/swappiness.pp
@@ -10,10 +10,9 @@
 # @author - Peter Souter
 #
 class swap_file::swappiness (
-  $swappiness = 60,
+  Integer[0,100] $swappiness = 60,
 ) {
 
-  validate_legacy(Integer, 'validate_integer', $swappiness, [100, 0])
 
   sysctl { 'vm.swappiness':
     ensure => 'present',

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.23.0 < 6.0.0"
+      "version_requirement": ">= 4.23.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/mount_core",

--- a/metadata.json
+++ b/metadata.json
@@ -56,12 +56,12 @@
       "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">=2.1.0 < 3.0.0"
+      "name": "puppet/augeasproviders_sysctl",
+      "version_requirement": ">=3.0.0 < 4.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">=2.1.0 < 3.0.0"
+      "name": "puppet/augeasproviders_core",
+      "version_requirement": ">=3.2.1 < 4.0.0"
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 describe 'swap_file' do
   let(:facts) do
     {
-      :memorysize => '1.00 GB',
-      selinux: true,
+      memory: { 'system' => {'total' => '1.00 GB'}},
+      os: {
+        'selinux' => { 'enabled' => 'true' },
+        'family' => 'RedHat',
+      }
+
     }
   end
 
@@ -50,8 +54,11 @@ describe 'swap_file' do
       {
         :fqdn              => 'files',
         :parameter_tests   => 'files_hiera_merge',
-        :memorysize        => '1.00 GB',
-        :selinux           => true,
+        memory: { 'system' => {'total' => '1.00 GB'}},
+        os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+        }
       }
     end
 
@@ -105,9 +112,11 @@ describe 'swap_file' do
     # set needed custom facts and variables
     let(:facts) do
       {
-        :osfamily => 'RedHat',
-        :memorysize => '1.00 GB',
-        :selinux    => true,
+        memory: { 'system' => {'total' => '1.00 GB'}},
+        os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+        }
       }
     end
     let(:validation_params) do

--- a/spec/defines/files_spec.rb
+++ b/spec/defines/files_spec.rb
@@ -5,12 +5,12 @@ describe 'swap_file::files' do
 
   let(:facts) do
     {
-      operatingsystem: 'RedHat',
-      osfamily: 'RedHat',
-      operatingsystemrelease: '7',
-      concat_basedir: '/tmp',
-      memorysize: '1.00 GB',
-      selinux: true,
+      memory: { 'system' => {'total' => '1.00 GB'}},
+      os: {
+        'selinux' => { 'enabled' => 'true' },
+        'family' => 'RedHat',
+        'release' => { 'major' => '7'},
+      },
     }
   end
 
@@ -138,16 +138,16 @@ describe 'swap_file::files' do
 
       let(:facts) do
         {
-          operatingsystem: 'RedHat',
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          concat_basedir: '/tmp',
-          memorysize: '1.00 GB',
           swapfile_sizes: {
             '/mnt/swap.resizeme' => existing_swap_kb,
           },
           swapfile_sizes_csv: "/mnt/swap.resizeme||#{existing_swap_kb}",
-          selinux: true,
+          memory: { 'system' => {'total' => '1.00 GB'}},
+          os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+          'release' => { 'major' => '7'},
+          },
         }
       end
 
@@ -191,13 +191,14 @@ describe 'swap_file::files' do
       end
       let(:facts) do
         {
-          operatingsystem: 'RedHat',
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          concat_basedir: '/tmp',
-          memorysize: '1.00 GB',
           swapfile_sizes: nil,
-          selinux: true,
+          swapfile_sizes_csv: "/mnt/swap.resizeme||#{existing_swap_kb}",
+          memory: { 'system' => {'total' => '1.00 GB'}},
+          os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+          'release' => { 'major' => '7'},
+          },
         }
       end
       it do
@@ -216,16 +217,16 @@ describe 'swap_file::files' do
       end
       let(:facts) do
         {
-          operatingsystem: 'RedHat',
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          concat_basedir: '/tmp',
-          memorysize: '1.00 GB',
+          memory: { 'system' => {'total' => '1.00 GB'}},
+          os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+          'release' => { 'major' => '7'},
+          },
           swapfile_sizes: {
             '/mnt/swap.differentname' => '204796', # 200MB
           },
           swapfile_sizes_csv: "/mnt/swap.differentname||#{existing_swap_kb}",
-          selinux: true,
         }
       end
       it do
@@ -254,14 +255,14 @@ describe 'swap_file::files' do
 
       let(:facts) do
         {
-          operatingsystem: 'RedHat',
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          concat_basedir: '/tmp',
-          memorysize: '1.00 GB',
+          memory: { 'system' => {'total' => '1.00 GB'}},
+          os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+          'release' => { 'major' => '7'}
+          },
           swapfile_sizes: "/mnt/swap.resizeme#{existing_swap_kb}",
           swapfile_sizes_csv: "/mnt/swap.resizeme||#{existing_swap_kb}",
-          selinux: true,
         }
       end
 
@@ -305,14 +306,14 @@ describe 'swap_file::files' do
       end
       let(:facts) do
         {
-          operatingsystem: 'RedHat',
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          concat_basedir: '/tmp',
-          memorysize: '1.00 GB',
+          memory: { 'system' => {'total' => '1.00 GB'}},
+          os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+          'release' => { 'major' => '7'}
+          },
           swapfile_sizes: nil,
           swapfile_sizes_csv: nil,
-          selinux: true,
         }
       end
       it do
@@ -331,14 +332,14 @@ describe 'swap_file::files' do
       end
       let(:facts) do
         {
-          operatingsystem: 'RedHat',
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          concat_basedir: '/tmp',
-          memorysize: '1.00 GB',
+          memory: { 'system' => {'total' => '1.00 GB'}},
+          os: {
+          'selinux' => { 'enabled' => 'true' },
+          'family' => 'RedHat',
+          'release' => { 'major' => '7'}
+          },
           swapfile_sizes: "/mnt/swap.differentname#{existing_swap_kb}",
           swapfile_sizes_csv: "/mnt/swap.differentname||#{existing_swap_kb}",
-          selinux: true,
         }
       end
       it do


### PR DESCRIPTION
Quite a few commits:

* Expect a hash as files input
* has_key is deprecated in stdlib
* is_hash is now deprecated
* Set non legacy facts in spec tests
* Use splat opeartor rather than create_resources
* Remove deprecate validate_functions
* Use $facts hash always
* Ingore .bundle directory
* Allow up to date gems for everything
* augeasprovides have migrated to voxpupuli space now
* Allow modern stdlib version 8

facts and function units still failing but its a start. Not checked the accept tests at all....

