### PR TITLE
Remove deprecated functions (`validate_legacy`, `hiera_hash`, `is_hash` and `has_key`)

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -32,23 +32,18 @@
 #    @petems - Peter Souter
 #
 define swap_file::files (
-  $ensure        = 'present',
-  $swapfile      = '/mnt/swap.1',
-  $swapfilesize  = $::memorysize,
-  $add_mount     = true,
-  $options       = 'defaults',
-  $timeout       = 300,
-  $cmd           = 'dd',
-  $resize_existing = false,
-  $resize_margin   = '50MB',
-  $resize_verbose  = false,
-)
-{
-  # Parameter validation
-  validate_legacy(String, 'validate_re', $ensure, ['^absent$', '^present$'])
-  validate_legacy(String, 'validate_string', $swapfile)
+  Enum['present','absent'] $ensure          = 'present',
+  Stdlib::Absolutefile     $swapfile        = '/mnt/swap.1',
+  String                   $swapfilesize    = $::memorysize,
+  String                   $options         = 'defaults',
+  String                   $cmd             = 'dd',
+  String                   $resize_margin   = '50MB',
+  Integer                  $timeout         = 300,
+  Boolean                  $add_mount       = true,
+  Boolean                  $resize_existing = false,
+  Boolean                  $resize_verbose  = false,
+) {
   $swapfilesize_mb = to_bytes($swapfilesize) / 1048576
-  validate_legacy(Boolean, 'validate_bool', $add_mount)
 
   if $ensure == 'present' {
 

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -46,12 +46,9 @@ define swap_file::files (
   $swapfilesize_mb = to_bytes($swapfilesize) / 1048576
 
   if $ensure == 'present' {
-
     if ($resize_existing and $::swapfile_sizes) {
-
-      if (is_hash($::swapfile_sizes)) {
-
-        if (has_key($::swapfile_sizes,$swapfile)) {
+      if $::swapfile_sizes =~ Hash {
+        if $swapfile in $::swapfile_sizes {
           ::swap_file::resize { $swapfile:
             swapfile_path          => $swapfile,
             margin                 => $resize_margin,
@@ -61,7 +58,6 @@ define swap_file::files (
             before                 => Exec["Create swap file ${swapfile}"],
           }
         }
-
       } else {
         $existing_swapfile_size = swap_file_size_from_csv($swapfile,$::swapfile_sizes_csv)
         if ($existing_swapfile_size) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,26 +40,13 @@
 # @author - Peter Souter
 #
 class swap_file (
-  $files             = {},
-  $files_hiera_merge = false,
+  Hash                                                                                          $files             = {},
+  Variant[Enum['Y','y','1','T','t','TRUE','true','0','F','f','N','n','false','FALSE'], Boolean] $files_hiera_merge = false,
 ) {
-
-  # variable handling
-  if $files_hiera_merge =~ Boolean {
-    $files_hiera_merge_bool = $files_hiera_merge
-  } else {
-    $files_hiera_merge_bool = str2bool($files_hiera_merge)
-  }
-  validate_legacy(Boolean, 'validate_bool', $files_hiera_merge_bool)
-
-  # functionality
-  if $files_hiera_merge_bool == true {
-    $files_real = hiera_hash('swap_file::files', {})
+  if str2bool($files_hiera_merge) {
+    $files_real = lookup('swap_file::files', Hash, { strategy => 'hash' }) 
   } else {
     $files_real = $files
   }
-  if $files_real != undef {
-    validate_legacy(Hash, 'validate_hash', $files_real)
-    create_resources('swap_file::files', $files_real)
-  }
+  create_resources('swap_file::files', $files_real)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class swap_file (
   Variant[Enum['Y','y','1','T','t','TRUE','true','0','F','f','N','n','false','FALSE'], Boolean] $files_hiera_merge = false,
 ) {
   if str2bool($files_hiera_merge) {
-    $files_real = lookup('swap_file::files', Hash, { strategy => 'hash' }) 
+    $files_real = lookup('swap_file::files', Hash, { strategy => 'hash' })
   } else {
     $files_real = $files
   }

--- a/manifests/resize.pp
+++ b/manifests/resize.pp
@@ -21,8 +21,7 @@ define swap_file::resize (
   $actual_swapfile_size,
   $margin                 = '50MB',
   $verbose                = false,
-)
-{
+) {
   $margin_bytes                  = to_bytes($margin)
   $existing_swapfile_bytes       = to_bytes("${actual_swapfile_size}kb")
   $expected_swapfile_size_bytes  = to_bytes($expected_swapfile_size)
@@ -31,7 +30,7 @@ define swap_file::resize (
     if !(difference_within_margin([$existing_swapfile_bytes, $expected_swapfile_size_bytes],$margin_bytes)) {
       if ($verbose) {
         $alert_message = "Existing : ${existing_swapfile_bytes}B\nExpected: ${expected_swapfile_size_bytes}B\nMargin: ${margin_bytes}B"
-        notify{"Resizing Swapfile Alert ${swapfile_path}":
+        notify { "Resizing Swapfile Alert ${swapfile_path}":
           name => $alert_message,
         }
       }
@@ -41,9 +40,8 @@ define swap_file::resize (
       } -> exec { "Purge ${swapfile_path} for resize":
         command => "/bin/rm -f ${swapfile_path}",
         onlyif  => "test -f ${swapfile_path}",
-        path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
+        path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
       }
     }
   }
-
 }

--- a/manifests/swappiness.pp
+++ b/manifests/swappiness.pp
@@ -16,5 +16,4 @@ class swap_file::swappiness (
     ensure => 'present',
     value  => $swappiness,
   }
-
 }

--- a/manifests/swappiness.pp
+++ b/manifests/swappiness.pp
@@ -10,11 +10,8 @@
 # @author - Peter Souter
 #
 class swap_file::swappiness (
-  $swappiness = 60,
+  Integer[0,100] $swappiness = 60,
 ) {
-
-  validate_legacy(Integer, 'validate_integer', $swappiness, [100, 0])
-
   sysctl { 'vm.swappiness':
     ensure => 'present',
     value  => $swappiness,


### PR DESCRIPTION
Since stdlib version 9.x, the `validate_legacy`, `is_hash` and `has_key` functions have been deprecated.
The `hiera_hash` function is also deprecated (I've replaced it with the `lookup` function with the 'hash' merge strategy).